### PR TITLE
Refactor Terraform validation and add outdated version warning.

### DIFF
--- a/src/terry/presentation/cli/action_handlers/about.py
+++ b/src/terry/presentation/cli/action_handlers/about.py
@@ -13,6 +13,9 @@ class AboutHandler(BaseTerraformActionHandler):
         )
         platform = self.app.terraform_version.platform if self.app.terraform_version else sys.platform
 
+        if self.app.terraform_version and self.app.terraform_version.terraform_outdated:
+            terraform_version = f"{terraform_version} (outdated)"
+
         self.app.push_screen(
             AboutScreen(
                 terraform_version=terraform_version,

--- a/src/terry/presentation/cli/screens/main/helpers.py
+++ b/src/terry/presentation/cli/screens/main/helpers.py
@@ -27,7 +27,7 @@ def validate_work_dir(path) -> None:
         raise PermissionError(f"Directory is not readable: {path}")
 
 
-def get_or_raise_validate_terraform(terraform_core_service):
+def get_terraform_version(terraform_core_service):
     """
     Validate the Terraform installation in the current environment.
 
@@ -40,11 +40,5 @@ def get_or_raise_validate_terraform(terraform_core_service):
 
     try:
         return terraform_core_service.version()
-    except TerraformVersionException as e:
-        error_message = (
-            "🚨\033[91mTerraform seems to be not installed.🚨\n"
-            "Please install Terraform to use this application.\n"
-            f"Details: {str(e)}"
-        )
-        print(error_message)
-        exit(1)
+    except TerraformVersionException:
+        return

--- a/src/terry/presentation/cli/screens/main/main.py
+++ b/src/terry/presentation/cli/screens/main/main.py
@@ -49,7 +49,7 @@ from terry.presentation.cli.screens.main.containers.header import Header
 from terry.presentation.cli.screens.main.containers.project_tree import ProjectTree
 from terry.presentation.cli.screens.main.containers.state_files import StateFiles
 from terry.presentation.cli.screens.main.containers.workspaces import Workspaces
-from terry.presentation.cli.screens.main.helpers import get_or_raise_validate_terraform, validate_work_dir
+from terry.presentation.cli.screens.main.helpers import get_terraform_version, validate_work_dir
 from terry.presentation.cli.screens.main.mixins.resize_containers_watcher_mixin import ResizeContainersWatcherMixin
 from terry.presentation.cli.screens.main.mixins.system_monitoring_mixin import SystemMonitoringMixin
 from terry.presentation.cli.screens.main.mixins.terraform_action_handler_mixin import TerraformActionHandlerMixin
@@ -362,7 +362,9 @@ class Terry(App, ResizeContainersWatcherMixin, TerraformActionHandlerMixin, Syst
             ValueError: If the working directory is invalid or the project is not a Terraform project.
         """
         validate_work_dir(self.work_dir)
-        self.terraform_version = get_or_raise_validate_terraform(self.terraform_core_service)
+        self.terraform_version = get_terraform_version(self.terraform_core_service)
+        if self.terraform_version and self.terraform_version.terraform_outdated:
+            self.notify("Terraform version is outdated.", severity="warning")
 
     def init_env(self):
         """


### PR DESCRIPTION
Replaced `get_or_raise_validate_terraform` with `get_terraform_version` to simplify the validation process and remove exit behavior. Added a warning notification for outdated Terraform versions in both main and "about" screens for enhanced user awareness. This improves user experience and code maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The Terraform version display now indicates when the version is outdated by appending a note, providing clearer information for users.
  - Users receive an explicit warning when an outdated Terraform version is detected.
  
- **Refactor**
  - The process for retrieving and validating the Terraform version has been streamlined to avoid abrupt failures, enhancing overall user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->